### PR TITLE
Type everything and simplify Multipliers logic

### DIFF
--- a/class/file_size.js
+++ b/class/file_size.js
@@ -1,33 +1,29 @@
 'use strict';
 
+const Units = Object.freeze({
+    B: Symbol("B"),
+    KB: Symbol("KB"),
+    MB: Symbol("MB"),
+    GB: Symbol("GB")
+});
+
+const Multipliers = {
+  [Units.B]: 1.0,
+  [Units.KB]: 100.0,
+  [Units.MB]: 1000000.0,
+  [Units.GB]: 1000000000.0
+}
+
 class FileSize {
-  constructor(value = 1, unit = 'MB') {
+  // unit options: B / KB / MB / GB
+  constructor(value = 1, unit = Units.MB) {
     this.value = value;
-    // unit options: B / KB / MB / GB
     this.unit = unit;
   }
 
   bytes() {
-    let multiplier = 1000000.0 // default to MB
-    switch (this.unit) {
-      case 'B':
-        multiplier = 1.0
-        break;
-      case 'KM':
-        multiplier = 100.0
-        break;
-      case 'MB':
-        multiplier = 1000000.0
-        break;
-      case 'GB':
-        multiplier = 1000000000.0
-        break;
-      default:
-        multiplier = 1000000.0
-    }
-
-    return this.value * multiplier;
+    return this.value * Multipliers.hasOwnProperty(this.unit) ? Multipliers[this.unit] : Multipliers[Units.MB];
   }
 }
 
-module.exports = FileSize;
+module.exports = {Units, FileSize};

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 "use strict";
 
-import FileSize from './class/file_size.js';
+import {FileSize, Units} from './class/file_size.js';
 
 const defaultChunkSizeInMb = 1
 
 let chunk = function(file, chunkSize) {
   if (!chunkSize) {
-    chunkSize = new FileSize(1, 'MB')
+    chunkSize = new FileSize(1, Units.MB)
   }
 
   if (file.size <= chunkSize.bytes()) {
@@ -46,7 +46,7 @@ function chunkArray(myArray, chunkSize){
   let index = 0;
   const arrayLength = myArray.length;
   let tempArray = [];
-  
+
   for (index = 0; index < arrayLength; index += chunkSize) {
       let chunk = myArray.slice(index, index+chunkSize);
       tempArray.push(chunk);
@@ -56,6 +56,7 @@ function chunkArray(myArray, chunkSize){
 }
 
 exports = module.exports = {
-  chunk: chunk,
-  FileSize: FileSize
+  chunk,
+  FileSize,
+  Units
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "file-chunker",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/chunk.test.js
+++ b/test/chunk.test.js
@@ -1,9 +1,9 @@
-import { chunk, FileSize } from '../';
+import { chunk, FileSize, Units } from '../';
 import test from 'tape';
 
 test("should return one file if it's less than chunk size", function (t) {
   var file = new File(["test"], "test.js")
-  chunk(file, new FileSize(1, 'MB'))
+  chunk(file, new FileSize(1, Units.MB))
     .then((files) => {
       t.equal(1, files.length);
       t.end();
@@ -22,13 +22,13 @@ test("should return multiple files if it's larger than chunk size", function (t)
       sb.push("</tr>");
   }
   sb.push("</table>");
-  
+
   var file = new File(sb, {type: 'application/vnd.ms-excel'});
 
-  var chunk_size = new FileSize(1, 'MB').bytes()
+  var chunk_size = new FileSize(1, Units.MB).bytes()
   var chunks = Math.ceil(file.size / chunk_size)
 
-  chunk(file, new FileSize(1, 'MB'))
+  chunk(file, new FileSize(1, Units.MB))
     .then((files) => {
       t.equal(chunks, files.length);
       t.end();


### PR DESCRIPTION
# Goal

- [x] To fix a _typo_ in the KB units (`s/KM/KB/`)
- [x] To type the accepted units [`B`; `KB`, `MB`, `GB`]
- [x] To simplify the _multipliers_ logic, avoiding a `switch / case` using a _strategy pattern_ approach
- [x] Tests
